### PR TITLE
plex api change?

### DIFF
--- a/src/plex.py
+++ b/src/plex.py
@@ -176,7 +176,7 @@ def uploadCollectionArt(plex):
         print(bcolors.FAIL + f'Could not find poster art directory. Expected location: {postersDir}.' + bcolors.ENDC)
         return
 
-    collections = plex.library.section(LIBRARY).collection()
+    collections = plex.library.section(LIBRARY).collections()
 
     # if there are no collections (same as len(collections) == 0)
     if not collections:


### PR DESCRIPTION
plex.library.section(LIBRARY).collection() requires a title now and fetches according to a title, which means you have to use collections() to retrieve the list of available collections from the category.
Without this the upload posters doesn't work currently